### PR TITLE
Update submodules, bump up ffmpeg, remove prepare-commands, fix build-commands for tekore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/com.github.taiko2k.tauonmb.json
+++ b/com.github.taiko2k.tauonmb.json
@@ -7,11 +7,11 @@
    "command":"com.github.taiko2k.tauonmb.sh",
    "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
-	    "version": "23.08",
-	    "directory": "lib/ffmpeg",
-	    "add-ld-path": ".",
-	    "autodelete": false
-	}
+        "version": "23.08",
+        "directory": "lib/ffmpeg",
+        "add-ld-path": ".",
+        "autodelete": false
+        }
    },
    "cleanup-commands": ["mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"],
    "finish-args":[
@@ -30,10 +30,7 @@
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.kde.StatusNotifierWatcher",
       "--own-name=org.mpris.MediaPlayer2.tauon"
-      
-   ],
-   "prepare-commands": [
-       "source /usr/lib/sdk/rust-stable/enable.sh"
+
    ],
    "modules":[
      "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json",

--- a/com.github.taiko2k.tauonmb.json
+++ b/com.github.taiko2k.tauonmb.json
@@ -112,9 +112,8 @@
          "name":"tauonmb-git",
          "buildsystem":"simple",
          "build-commands":[
-            "bash compile-phazor.sh",
-            "bash compile-phazor-pipewire.sh",
-            "python3 compile-translations.py",
+            "bash run.sh 5",
+            "python3 compile_translations.py",
             "mkdir -p /app/share/locale",
             "mv locale /app/share/",
             "mkdir -p /app/bin",

--- a/com.github.taiko2k.tauonmb.json
+++ b/com.github.taiko2k.tauonmb.json
@@ -7,7 +7,7 @@
    "command":"com.github.taiko2k.tauonmb.sh",
    "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
-        "version": "23.08",
+        "version": "24.08",
         "directory": "lib/ffmpeg",
         "add-ld-path": ".",
         "autodelete": false

--- a/python-tekore-deps.json
+++ b/python-tekore-deps.json
@@ -29,9 +29,9 @@
 
             "build-commands": [
                       "cargo --offline fetch --manifest-path Cargo.toml --verbose",
-		      "cargo --offline build --release --verbose",
-		      "install -Dm755 target/release/maturin -t ${FLATPAK_DEST}/bin",
-		      "install -Dm644 maturin/__init__.py -t ${FLATPAK_DEST}/lib/python$(python -c 'import sys; print(\"%s.%s\" %sys.version_info[0:2])')/site-packages/maturin/"
+                      "cargo --offline build --release --verbose",
+                      "install -Dm755 target/release/maturin -t ${FLATPAK_DEST}/bin",
+                      "install -Dm644 maturin/__init__.py -t ${FLATPAK_DEST}/lib/python$(python -c 'import sys; print(\"%s.%s\" %sys.version_info[0:2])')/site-packages/maturin/"
             ],
             "sources": [
                     "maturin-cargo.json",

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -293,8 +293,7 @@
             "name": "python3-tekore",
             "buildsystem": "simple",
             "build-commands": [
-                "source /usr/lib/sdk/rust-stable/enable.sh",
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"tekore\" --no-build-isolation"
+                "source /usr/lib/sdk/rust-stable/enable.sh && pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"tekore\" --no-build-isolation"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Current submodules are 4 years old.

ffmpeg can install 24.08 nowadays.

prepare-commands does not exist? Removed.

build-commands needs to source rust in the same shell instance.