### PR TITLE
remove ffmpeg-full extension, not needed for gnome runtime >= 49

### DIFF
--- a/com.github.taiko2k.tauonmb.json
+++ b/com.github.taiko2k.tauonmb.json
@@ -7,17 +7,6 @@
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
     "command": "com.github.taiko2k.tauonmb.sh",
-    "add-extensions": {
-        "org.freedesktop.Platform.ffmpeg-full": {
-            "version": "24.08",
-            "directory": "lib/ffmpeg",
-            "add-ld-path": ".",
-            "autodelete": false
-        }
-    },
-    "cleanup-commands": [
-        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
-    ],
     "finish-args": [
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
The extension org.freedesktop.Platform.ffmpeg-full has been replaced with org.freedesktop.Platform.codecs-extra since Freedesktop SDK 25.08. It is now also automatically pulled in by GNOME runtime >= 49.

Instead of opt-in it is not opt-out via a masking logic. Tauon needs ffmpeg with the extra codecs, so remove the legacy override.

https://docs.flatpak.org/en/latest/extension.html
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/24620
https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/931

Fixes #70 