### PR TITLE
Test: Use the SDL3 modules from the runtime

### DIFF
--- a/com.github.taiko2k.tauonmb.json
+++ b/com.github.taiko2k.tauonmb.json
@@ -35,7 +35,6 @@
         "python3-modules.json",
         "librespot.json",
         "fonts.json",
-        "sdl3.json",
         {
             "name": "libopenmpt",
             "buildsystem": "autotools",


### PR DESCRIPTION
Freedesktop runtime 25.08 and related runtimes (GNOME 49, KDE 6.10, and KDE 5.15-25.08) provide several SDL modules that might be useful to drop from the build manifest.

Fixes: https://github.com/flathub/com.github.taiko2k.tauonmb/issues/83